### PR TITLE
resolvers and ipsources need to be arrays in config.json

### DIFF
--- a/templates/config.erb
+++ b/templates/config.erb
@@ -11,7 +11,7 @@
   "ttl": <%=@ttl%>,
   "domain": "<%=@domain%>",
   "port": <%=@port%>,
-  "resolvers": <%=@resolvers%>,
+  "resolvers": <%=@resolvers.inspect%>,
   "timeout": <%=@timeout%>,
   "listener": "<%=@listener%>",
   "dnson": <%=@dns_on%>,
@@ -26,5 +26,5 @@
   "SOAMinttl": <%=@soa_minttl%>,
   "recurseon": <%=@recurse_on%>,
   "enforceRFC952": <%=@enforce_rfc952%>,
-  "IPSources": <%=@ip_sources%>
+  "IPSources": <%=@ip_sources.inspect%>
 }


### PR DESCRIPTION
In a default configuration where resolvers or ipsources are not explicitly set, the default values are not valid configuration values for mesos-dns.  The default value for resolvers ['8.8.8.8'] is converted to 8.8.8.8 which is invalid configuration and prevents the service from starting.

I'm seeing this using puppet 3.8.7 on CentOS 7, so not sure if its specific to to my version.  Doing a .inspect on the values in the ERB template outputs the array as required.